### PR TITLE
Fixed #2 (Make MongoDB port configurable)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY conf/supervisord.conf /etc/
 
 # Install the PHP extensions we need
 #RUN docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr
-RUN docker-php-ext-install opcache zip mcrypt mbstring > /dev/null 2>&1
+RUN docker-php-ext-install pcntl bcmath opcache zip mcrypt mbstring > /dev/null 2>&1
 
 # Install PHP pecl mongo
 COPY bin/* /usr/local/bin/

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -56,6 +56,9 @@ set -e
 		# "${LEARNINGLOCKER_DB_HOST}/admin" < /tmp/createUser.js
 	# rm /tmp/createUser.js
 
+        # Set the MongoDB port to a default value if the user didn't provide one
+        LEARNINGLOCKER_DB_PORT=${LEARNINGLOCKER_DB_PORT:-27017}
+
 	# Setup database connection to mongodb
 	if [ ! -e app/config/local/database.php ]; then
 		if [ -z "$LEARNINGLOCKER_DB_REPLICA_SET" ]; then
@@ -66,7 +69,7 @@ set -e
 						'mongodb' => [
 							'driver'   => 'mongodb',
 							'host'     => '${LEARNINGLOCKER_DB_HOST}',
-							'port'     => 27017,
+							'port'     => '${LEARNINGLOCKER_DB_PORT}',
 							'database' => '$LEARNINGLOCKER_DB_NAME',
 							'username' => '${LEARNINGLOCKER_DB_USER}',
 							'password' => '${LEARNINGLOCKER_DB_PASSWORD}'
@@ -82,7 +85,7 @@ set -e
 						'mongodb' => [
 							'driver'   => 'mongodb',
 							'host'     => array(${LEARNINGLOCKER_DB_HOST}),
-							'port'     => 27017,
+							'port'     => '${LEARNINGLOCKER_DB_PORT}',
 							'database' => '$LEARNINGLOCKER_DB_NAME',
 							'username' => '${LEARNINGLOCKER_DB_USER}',
 							'password' => '${LEARNINGLOCKER_DB_PASSWORD}',


### PR DESCRIPTION
Hi @zapur1 !

Following up from the ticket I've opened yesterday, I went on and modified the entrypoint script to allow a custom MongoDB port to be passed. I also had (for some reason!) to install a couple of extra PHP extensions or `docker build` wouldn't complete successfully. 

I have tested this locally and it works as it should. Do you think it would be possible to review, merge this, release an updated (possibly tagged) image on Docker Hub? Many thanks!

cc @filib